### PR TITLE
Add compat package that register driver as sqlite3

### DIFF
--- a/compat/compat.go
+++ b/compat/compat.go
@@ -1,0 +1,7 @@
+package compat
+
+import "github.com/glebarez/go-sqlite"
+
+func init() {
+	sqlite.RegisterAsSQLITE3()
+}

--- a/sqlite.go
+++ b/sqlite.go
@@ -1741,3 +1741,7 @@ func registerScalarFunction(
 
 	return nil
 }
+
+func RegisterAsSQLITE3() {
+	sql.Register("sqlite3", newDriver())
+}


### PR DESCRIPTION
As discussed in #88 external libraries like `ent` use the `sqlite3` as `sqlite` driver. Thus, it is necessary that the driver is registered under `sqlite3`.

This PR adds a  `compat` package that makes it possible to Register it as sqlite3 with a simple import
``` go
import _ "github.com/glebarez/go-sqlite/compat"
```

One basic problem is that the global driver is not exported, and the `RegisterDeterministicScalarFunction` acts on the global driver. Thus, some exported function that makes it possible to Register the global driver externally is needed.

I solved this problem by a simple `RegisterAsSQLITE3` method. Thus, I believe there is little impact on the API definition.
The only other way I am aware of to resolve this would be an internal package that contains the global driver and is imported on both points. However, this needs a larger refactor. Thus, I go with the simpler solution here.

